### PR TITLE
Improved identification of unique timertrees.

### DIFF
--- a/example/cpp_test/Makefile
+++ b/example/cpp_test/Makefile
@@ -7,9 +7,9 @@ INCLUDES =
 
 # C++ compiler flags (-g -O2 -Wall)
 CCFLAGS = -O3 -I../../include  -fopenmp
-LDFLAGS = -L../../lib -lphiprof  -lgomp -ldl
+LDFLAGS = -L../../lib -lphiprof  -lgomp -ldl -lrt
 # compiler
-CCC = CC
+CCC = mpiCC
 
 
 .SUFFIXES: .cpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ CLOCK_ID = CLOCK_MONOTONIC
 CCFLAGS = -fpic -O3 -fopenmp -std=c++11 -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
 
 # compiler
-CCC = CC
+CCC = mpiCC
 
 # library paths
 LIBS = 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -23,19 +23,6 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 #define COMMON_H
 #include <time.h>
 
-//djb2 hash function copied from
-//http://www.cse.yorku.ca/~oz/hash.html
-//TODO: replace by a better one
-inline unsigned long hash(const char *str) {
-   unsigned long hash = 5381;
-   int c;
-   while ( (c = *str++) )
-      hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-   return hash;
-}
-
-
-
 //this function returns the time in seconds . 
 inline double wTime(){
 //time struct to get wall time

--- a/src/timerdata.hpp
+++ b/src/timerdata.hpp
@@ -194,25 +194,16 @@ public:
 
    
 
-//Hash value identifying all labels, groups and workunitlabels.
-//If any std::strings differ, hash should differ. Computed recursively in the same way as prints
-   int getHash() const{
-      unsigned long hashValue;
-      //add hash values from label, workunitlabel and groups. Everything has to match.
-      hashValue=hash(label.c_str());
-      hashValue+=hash(workUnitLabel.c_str());
-      for (std::vector<std::string>::const_iterator g = groups.begin();g != groups.end(); ++g ) {
-         hashValue+=hash((*g).c_str());
+//String with label, groups and workunitlabel.
+   std::string getStringForHash() const{
+      std::string hashString = label;
+      hashString += workUnitLabel;
+      for (const auto& g: groups) {
+         hashString += g;
       }
-      
-      // MPI_Comm_split needs a non-zero value
-      if (hashValue == 0) {
-         return 1;
-      } else {
-         //we return an integer value
-         return hashValue%std::numeric_limits<int>::max();
-      }
+      return hashString;
    }
+   
    
    void resetTime(double resetWallTime){
       count.assign(count.size(), 0);

--- a/src/timertree.hpp
+++ b/src/timertree.hpp
@@ -21,6 +21,7 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef TIMERTREE_H
 #define TIMERTREE_H
 #include <vector>
+#include <string>
 #include "timerdata.hpp"
 #ifdef _OPENMP
 #include <omp.h>
@@ -173,12 +174,13 @@ public:
    double getTime(int id) const;
    int getChildId(const std::string &label) const;
    double getGroupTime(std::string group, int id) const;
-   int getHash(int id=0) const;
+   int getHash() const;
    std::string getFullLabel(int id,bool reverse=false) const;  
 
 
 
 protected:
+   std::string getHashString(int id) const;
    
 
    static int setThreadCounts(){
@@ -207,7 +209,7 @@ protected:
 
    std::vector<int> currentId;
    std::vector<TimerData> timers;
-
+   
 
    
 };


### PR DESCRIPTION
Now it first constructs one long string describing the whole tree, and from this the
hash is computed. This is much more robust than the earlier one which did not properly
take order and position in tree into account, since all timers were added individually.

This fixes crashes caused by computing statistics from two different timer trees.