### PR TITLE
Fix crash in getAverageCount or getAverageWorkUnits if timedThreads==0

### DIFF
--- a/src/timerdata.hpp
+++ b/src/timerdata.hpp
@@ -166,7 +166,11 @@ public:
          }
       }
       //TODO, should return double
-      return sumCount / timedThreads;
+      if(timedThreads == 0) {
+         return 0;
+      } else {
+         return sumCount / timedThreads;
+      }
    }
 
    double getAverageWorkUnits() const{
@@ -178,7 +182,11 @@ public:
             sumWorkUnits += workUnits[i];
          }
       }
-      return sumWorkUnits / timedThreads;
+      if(timedThreads == 0) {
+         return 0;
+      } else {
+         return sumWorkUnits / timedThreads;
+      }
    }
 
 


### PR DESCRIPTION
This can happen in vlasiator multipop runs, where one population does not fill the entire simulation space, so that certain parts of the code are never run for some tasks.