### PR TITLE
Nvtx profiling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Not supported
 
 2) Edit Makefile if needed to set the correct compilation options and
 compiler names. Phiprof should be compiled with a MPI compiler and
-openmp threading should be enabled
+openmp threading should be enabled. The compiler environment can also be
+set from the command line, for example "make CC=pgi".
 
 3) make 
 
@@ -58,6 +59,9 @@ define the region, that has been obtained by a preceeding
 `phiprof::initializeTimer(...)` call, since that is the only one that
 does not include a critical region synchronization.
 
+Profiling OpenACC programs: If compiled with a PGI compiler and NVTX 
+support, and if the OPENACC environment variable is set, each phiprof
+timer will also activate a corresponding NVTX region.
 
 ### Running code 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Not supported
 2) Edit Makefile if needed to set the correct compilation options and
 compiler names. Phiprof should be compiled with a MPI compiler and
 openmp threading should be enabled. The compiler environment can also be
-set from the command line, for example "make CC=pgi".
+set from the command line, for example "make CC=nvcc CCC=nvcc".
 
 3) make 
 

--- a/example/nvtx_test/Makefile
+++ b/example/nvtx_test/Makefile
@@ -1,0 +1,29 @@
+# source files.
+SRC = test.cpp
+OBJ = $(SRC:.cpp=.o)
+
+# include directories
+INCLUDES = 
+
+# add compiler flag -D_NVTX to include NVTX range analysis in phiprof
+# test includes small openacc region so compiler is given -acc and -Minfo=accel
+
+# C++ compiler flags (-g -O2 -Wall)
+CCFLAGS = -O3 -I../../include -acc -Minfo=accel -D_NVTX
+LDFLAGS = -L../../lib -lphiprof -acc -ldl -lrt -lnvToolsExt -L/appl/spack/install-tree/gcc-4.8.5/cuda-10.1.168-v5izax/lib64
+# compiler
+CCC = mpic++
+
+
+.SUFFIXES: .cpp
+
+default: $(OBJ) 
+	$(CCC) -o test  $(OBJ) $(LDFLAGS)   
+
+.cpp.o:
+	$(CCC) $(INCLUDES) $(CCFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) test
+
+

--- a/example/nvtx_test/Makefile
+++ b/example/nvtx_test/Makefile
@@ -8,12 +8,18 @@ INCLUDES =
 # add compiler flag -D_NVTX to include NVTX range analysis in phiprof
 # test includes small openacc region so compiler is given -acc and -Minfo=accel
 
+# Run test with e.g.
+# srun -n1 -p gputest --gres=gpu:v100:1 --account=project_2000203 --time=00:02:30 nvprof -f -o out.nvvp ./test
+
 # C++ compiler flags (-g -O2 -Wall)
 CCFLAGS = -O3 -I../../include -acc -Minfo=accel -D_NVTX
 LDFLAGS = -L../../lib -lphiprof -acc -ldl -lrt -lnvToolsExt -L/appl/spack/install-tree/gcc-4.8.5/cuda-10.1.168-v5izax/lib64
 # compiler
 CCC = mpic++
 
+#PGI openmp support
+CCFLAGS += -mp
+LDFLAGS += -mp
 
 .SUFFIXES: .cpp
 

--- a/example/nvtx_test/test.cpp
+++ b/example/nvtx_test/test.cpp
@@ -1,0 +1,162 @@
+/*
+  This file is part of the phiprof library
+
+  Copyright 2011, 2012 Finnish Meteorological Institute
+
+  Phiprof is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+#include <iostream>
+#include <iomanip> 
+#include <string>    
+#include <vector>     
+#include "mpi.h"
+#include "omp.h"
+#include "phiprof.hpp"
+
+using namespace std;
+
+double compute(double seconds){
+   const double overhead=0.000002; //estimated
+   double a,b,c,d;
+   int  i,iterations=1000;
+   double t1,t2;
+
+   a=1.00004;
+   b=1e-10;
+   c=1.00011;
+   d=0;
+
+   t2=t1=MPI_Wtime();
+   while(t2-t1<seconds-overhead){
+      #pragma acc parallel loop
+      for(i=0;i<iterations;i++){
+         d+=a*b+c;
+      }
+      t2=MPI_Wtime();
+   }
+   return d;
+}
+
+
+int main(int argc,char **argv){
+
+   int rank;
+   MPI_Init(&argc,&argv);
+   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+   //const int nIterations=1000000;
+   const int nIterations=10;
+   if(rank==0)
+      cout << "Measuring performance of start-stop calls" <<endl;
+   
+   phiprof::initialize();
+   
+   phiprof::start("Benchmarking phiprof"); 
+
+   phiprof::start("Initalized timers using ID");
+
+   if(rank==0)
+      cout << "  1/3" <<endl;
+   int id_a=phiprof::initializeTimer("a","A with ID");
+   for(int i=0;i<nIterations;i++){
+      phiprof::start(id_a);
+      phiprof::stop(id_a);
+   }
+   phiprof::stop("Initalized timers using ID",nIterations,"start-stop");
+
+   if(rank==0)
+      cout << "  2/3" <<endl;
+
+   phiprof::start("Re-initialized timers using ID");
+   for(int i=0;i<nIterations;i++){
+      id_a=phiprof::initializeTimer("a","A with ID");
+      phiprof::start(id_a);
+      phiprof::stop(id_a);
+   }
+   phiprof::stop("Re-initialized timers using ID",nIterations,"start-stop");
+
+   if(rank==0)
+      cout << "  3/3" <<endl;
+   phiprof::start("Timers using labels");
+   for(int i=0;i<nIterations;i++){
+      phiprof::start("a");
+      phiprof::stop("a");
+   }
+   phiprof::stop("Timers using labels", nIterations*2, "start-stop");
+   phiprof::stop("Benchmarking phiprof"); 
+
+   MPI_Barrier(MPI_COMM_WORLD);
+ 
+   if(rank==0)
+      cout << "Measuring accuracy" <<endl;
+
+
+   phiprof::start("Test accuracy");
+
+   if(rank==0)
+      cout << "  1/3" <<endl;
+   phiprof::start("100x0.01s computations"); 
+   for(int i=0;i<100;i++){
+      phiprof::start("compute");
+      compute(0.01);
+      phiprof::stop("compute");
+   }
+   phiprof::stop("100x0.01s computations");
+
+   if(rank==0)
+      cout << "  2/3" <<endl;
+   MPI_Barrier(MPI_COMM_WORLD);
+
+   phiprof::start("100 x 0.01 (threadId + 1)s, ID");
+   int id = phiprof::initializeTimer("compute");
+#pragma omp parallel
+   for(int i=0;i<100;i++){
+      phiprof::start(id);
+      compute(0.01 * (omp_get_thread_num() + 1));
+      phiprof::stop(id);
+   }
+   phiprof::stop("100 x 0.01 (threadId + 1)s, ID"); 
+
+   if(rank==0)
+      cout << "  3/3" <<endl;
+   MPI_Barrier(MPI_COMM_WORLD);
+
+   phiprof::start("100 x 0.01 (threadId + 1)s, String");
+#pragma omp parallel
+   for(int i=0;i<100;i++){
+      phiprof::start("compute");
+      compute(0.01 * (omp_get_thread_num() + 1));
+      phiprof::stop("compute");
+   }
+   phiprof::stop("100 x 0.01 (threadId + 1)s, String");
+
+
+
+    phiprof::stop("Test accuracy");
+
+   if(rank%2 == 1) {
+      
+      phiprof::start("Test-profile-groups");
+      phiprof::stop("Test-profile-groups");
+   }
+   
+
+   MPI_Barrier(MPI_COMM_WORLD);
+   double t1=MPI_Wtime();
+   phiprof::print(MPI_COMM_WORLD);
+   if(rank==0)   
+      cout<< "Print time is "<<MPI_Wtime()-t1<<endl;
+//   phiprof::print(MPI_COMM_WORLD,0.1);
+   MPI_Finalize();
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 # source files.
 SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
 SRC_NO = nophiprof.cpp phiprof_c.cpp
-OBJ = $(SRC:.cpp=.o) phiprof_fortran.o
-OBJ_NO = $(SRC_NO:.cpp=.o) phiprof_fortran.o
+OBJ = $(SRC:.cpp=.o) 
+OBJ_NO = $(SRC_NO:.cpp=.o) 
 OUT_STATIC = ../lib/libphiprof.a
 OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
@@ -17,11 +17,11 @@ OUT_SHARED_NO = ../lib/libnophiprof.so
 CLOCK_ID = CLOCK_MONOTONIC
 
 # C++ compiler flags 
-CCFLAGS = -fpic -O3 -fopenmp -std=c++11 -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
+CCFLAGS = -g -fpic -O3 -std=c++11 -D_NVTX -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
 FFLAGS= -fpic -O3
 # compiler
 CCC = mpic++
-FTN = mpifort
+FTN = mpif90
 
 # compile flags
 LDFLAGS =  -lgomp -lstdc++ 
@@ -29,20 +29,16 @@ LDFLAGS =  -lgomp -lstdc++
 .SUFFIXES: .cpp
 
 
-default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
+default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED)  $(OUT_SHARED_NO) 
 
-static:  $(OUT_STATIC) $(OUT_STATIC_NO) phiprof.mod
+static:  $(OUT_STATIC) $(OUT_STATIC_NO)
 
-shared: $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
+shared: $(OUT_SHARED)  $(OUT_SHARED_NO)
 
 
 .cpp.o:
 	$(CCC) $(CCFLAGS) -c $< -o $@
 
-phiprof.mod: phiprof.f90 phiprof_fortran.o
-
-phiprof_fortran.o: phiprof.f90 
-	$(FTN) $(FFLAGS) -c phiprof.f90 -o phiprof_fortran.o
 
 $(OUT_STATIC): $(OBJ) libdir includedir
 	ar rcs $(OUT_STATIC) $(OBJ)
@@ -60,14 +56,14 @@ $(OUT_SHARED_NO): $(OBJ_NO) libdir
 libdir:
 	mkdir -p ../lib
 
-includedir: phiprof.mod
+includedir: 
 	mkdir -p ../include
-	cp phiprof.hpp phiprof.h phiprof.mod ../include
+	cp phiprof.hpp phiprof.h ../include
 
 
 
 clean:
-	rm -f $(OBJ) *.mod $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO)
+	rm -f $(OBJ) $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO)
 
 phiprof.o: phiprof.hpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,12 @@ OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
 OUT_SHARED_NO = ../lib/libnophiprof.so
 
+# Set the default compiler type (pgi, gcc, intel). Can be overriden from command-line.
+CC = gcc
 
+# compiler calls
+CCC = mpicxx
+FTN = mpifort
 
 #Set clock.
 #CLOCK_MONOTONIC_COARSE is (much) faster, but has very poor
@@ -19,26 +24,22 @@ OUT_SHARED_NO = ../lib/libnophiprof.so
 CLOCK_ID = CLOCK_MONOTONIC
 
 # C++ compiler flags 
-CCFLAGS = -fpic -O2 -std=c++17 -DCLOCK_ID=$(CLOCK_ID) #-W -Wall -Wextra -pedantic 
+CCFLAGS = -fpic -O2 -std=c++17 -DCLOCK_ID=$(CLOCK_ID)
 FFLAGS= -fpic -O2
-
-# compiler (GCC)
-CCC = mpicxx
-FTN = mpifort
-
-# Optional flag to add NVTX profiling
-CCFLAGS += -D_NVTX
-
-# compile flags
 LDFLAGS = -lstdc++ 
 
-# Add GCC OpenMP support
-#CCFLAGS += -fopenmp
-#LDFLAGS += -lgomp
-
-# Add PGI OpenMP support
-CCFLAGS += -mp
-LDFLAGS += -mp
+# Compiler-specific options
+ifeq ($(CC),pgi)
+   # Add openmp, NVTX profiling, warnings
+   CCFLAGS += -mp -D_NVTX --remarks -Minform=inform # -a --pedantic give even more warnings
+   LDFLAGS += -mp
+else ifeq ($(CC),gcc)
+   CCFLAGS += -fopenmp -W -Wall -Wextra -pedantic 
+   LDFLAGS += -lgomp
+else ifeq ($(CC),intel)
+   CCFLAGS += -qopenmp -W -Wall -Wextra -pedantic 
+   LDFLAGS += -qopenmp
+endif
 
 .SUFFIXES: .cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 # source files.
 SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
 SRC_NO = nophiprof.cpp phiprof_c.cpp
-OBJ = $(SRC:.cpp=.o) 
-OBJ_NO = $(SRC_NO:.cpp=.o) 
+OBJ = $(SRC:.cpp=.o) phiprof_fortran.o
+OBJ_NO = $(SRC_NO:.cpp=.o) phiprof_fortran.o
 OUT_STATIC = ../lib/libphiprof.a
 OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
@@ -16,12 +16,15 @@ OUT_SHARED_NO = ../lib/libnophiprof.so
 # clock_gettime
 CLOCK_ID = CLOCK_MONOTONIC
 
-# C++ compiler flags 
-CCFLAGS = -g -fpic -O3 -std=c++11 -D_NVTX -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
+# C++ compiler flags
+CCFLAGS = -fpic -O3 -fopenmp -std=c++11 -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
 FFLAGS= -fpic -O3
 # compiler
 CCC = mpic++
-FTN = mpif90
+FTN = mpifort
+
+# Optional flag to add NVTX profiling
+#CCFLAGS = $(CCFLAGS) -D_NVTX
 
 # compile flags
 LDFLAGS =  -lgomp -lstdc++ 
@@ -29,16 +32,20 @@ LDFLAGS =  -lgomp -lstdc++
 .SUFFIXES: .cpp
 
 
-default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED)  $(OUT_SHARED_NO) 
+default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
 
-static:  $(OUT_STATIC) $(OUT_STATIC_NO)
+static:  $(OUT_STATIC) $(OUT_STATIC_NO) phiprof.mod
 
-shared: $(OUT_SHARED)  $(OUT_SHARED_NO)
+shared: $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
 
 
 .cpp.o:
 	$(CCC) $(CCFLAGS) -c $< -o $@
 
+phiprof.mod: phiprof.f90 phiprof_fortran.o
+
+phiprof_fortran.o: phiprof.f90 
+	$(FTN) $(FFLAGS) -c phiprof.f90 -o phiprof_fortran.o
 
 $(OUT_STATIC): $(OBJ) libdir includedir
 	ar rcs $(OUT_STATIC) $(OBJ)
@@ -56,14 +63,14 @@ $(OUT_SHARED_NO): $(OBJ_NO) libdir
 libdir:
 	mkdir -p ../lib
 
-includedir: 
+includedir: phiprof.mod
 	mkdir -p ../include
-	cp phiprof.hpp phiprof.h ../include
+	cp phiprof.hpp phiprof.h phiprof.mod ../include
 
 
 
 clean:
-	rm -f $(OBJ) $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO)
+	rm -f $(OBJ) *.mod $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO)
 
 phiprof.o: phiprof.hpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,4 @@
+
 # source files.
 SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
 SRC_NO = nophiprof.cpp phiprof_c.cpp
@@ -10,8 +11,8 @@ OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
 OUT_SHARED_NO = ../lib/libnophiprof.so
 
-# Set the default compiler type (pgi, gcc, intel, clang). Can be overriden from command-line.
-CC = gcc
+# Set the default compiler type (pgi, nvcc, gcc, intel, clang). Can be overriden from command-line.
+CC = nvcc
 
 # compiler calls
 CCC = mpicxx
@@ -36,6 +37,11 @@ ifeq ($(CC),pgi)
    # Add openmp, NVTX profiling, warnings
    CCFLAGS += -mp -D_NVTX --remarks -Minform=inform # -a --pedantic give even more warnings
    LDFLAGS += -mp
+else ifeq ($(CC),nvcc)
+   # needs extra --compiler-options
+   CCFLAGS = --compiler-options -fpic -O2 -std=c++17 -DCLOCK_ID=$(CLOCK_ID)
+   CCFLAGS +=  -D_NVTX -Xcompiler -fopenmp
+   LDFLAGS += -lgomp -lnvToolsExt
 else ifeq ($(CC),gcc)
    CCFLAGS += -fopenmp -W -Wall -Wextra -pedantic 
    LDFLAGS += -lgomp

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,14 +24,14 @@ CCC = mpic++
 FTN = mpifort
 
 # Optional flag to add NVTX profiling
-#CCFLAGS += -D_NVTX
+CCFLAGS += -D_NVTX
 
 # compile flags
 LDFLAGS = -lstdc++ 
 
 # Add OpenMP support
-CCFLAGS += -fopenmp 
-LDFLAGS += -lgomp
+CCFLAGS += -mp #-fopenmp
+LDFLAGS += -mp -lgomp
 
 .SUFFIXES: .cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,12 +10,14 @@ OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
 OUT_SHARED_NO = ../lib/libnophiprof.so
 
-# Set the default compiler type (pgi, gcc, intel). Can be overriden from command-line.
+# Set the default compiler type (pgi, gcc, intel, clang). Can be overriden from command-line.
 CC = gcc
 
 # compiler calls
 CCC = mpicxx
 FTN = mpifort
+#CCC = mpic++
+#FTN = mpif90
 
 #Set clock.
 #CLOCK_MONOTONIC_COARSE is (much) faster, but has very poor
@@ -26,6 +28,7 @@ CLOCK_ID = CLOCK_MONOTONIC
 # C++ compiler flags 
 CCFLAGS = -fpic -O2 -std=c++17 -DCLOCK_ID=$(CLOCK_ID)
 FFLAGS= -fpic -O2
+
 LDFLAGS = -lstdc++ 
 
 # Compiler-specific options
@@ -39,6 +42,9 @@ else ifeq ($(CC),gcc)
 else ifeq ($(CC),intel)
    CCFLAGS += -qopenmp -W -Wall -Wextra -pedantic 
    LDFLAGS += -qopenmp
+else ifeq ($(CC),clang)
+   CCFLAGS += -fopenmp -W -Wall -Wextra -pedantic -mp -D_NVTX --remarks -Minform=inform # -a --pedantic give even more warnings
+   LDFLAGS += -lgomp -mp
 endif
 
 .SUFFIXES: .cpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,14 +1,14 @@
 # source files.
-SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
+SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp phiprof.cpp phiprof_c.cpp 
 SRC_NO = nophiprof.cpp phiprof_c.cpp
-OBJ = $(SRC:.cpp=.o) phiprof_fortran.o
-OBJ_NO = $(SRC_NO:.cpp=.o) phiprof_fortran.o
+OBJ = $(SRC:.cpp=.o)
+OBJ_NO = $(SRC_NO:.cpp=.o)
+FOBJ = phiprof_fortran.o
+FOBJ_NO = phiprof_fortran.o
 OUT_STATIC = ../lib/libphiprof.a
 OUT_STATIC_NO = ../lib/libnophiprof.a
 OUT_SHARED = ../lib/libphiprof.so
 OUT_SHARED_NO = ../lib/libnophiprof.so
-
-
 
 #Set clock.
 #CLOCK_MONOTONIC_COARSE is (much) faster, but has very poor
@@ -17,27 +17,31 @@ OUT_SHARED_NO = ../lib/libnophiprof.so
 CLOCK_ID = CLOCK_MONOTONIC
 
 # C++ compiler flags
-CCFLAGS = -fpic -O3 -fopenmp -std=c++11 -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
+CCFLAGS = -fpic -O3 -std=c++11 -DCLOCK_ID=$(CLOCK_ID) #-DDEBUG_PHIPROF_TIMERS # -W -Wall -Wextra -pedantic 
 FFLAGS= -fpic -O3
 # compiler
 CCC = mpic++
 FTN = mpifort
 
 # Optional flag to add NVTX profiling
-#CCFLAGS = $(CCFLAGS) -D_NVTX
+#CCFLAGS += -D_NVTX
 
 # compile flags
-LDFLAGS =  -lgomp -lstdc++ 
+LDFLAGS = -lstdc++ 
+
+# Add OpenMP support
+CCFLAGS += -fopenmp 
+LDFLAGS += -lgomp
 
 .SUFFIXES: .cpp
 
+default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO) phiprof.mod includedir
 
-default: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
+nofortran: $(OUT_STATIC) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO) nofortranincludedir
 
-static:  $(OUT_STATIC) $(OUT_STATIC_NO) phiprof.mod
+static:  $(OUT_STATIC) $(OUT_STATIC_NO) phiprof.mod includedir
 
-shared: $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod
-
+shared: $(OUT_SHARED)  $(OUT_SHARED_NO) phiprof.mod includedir
 
 .cpp.o:
 	$(CCC) $(CCFLAGS) -c $< -o $@
@@ -47,12 +51,11 @@ phiprof.mod: phiprof.f90 phiprof_fortran.o
 phiprof_fortran.o: phiprof.f90 
 	$(FTN) $(FFLAGS) -c phiprof.f90 -o phiprof_fortran.o
 
-$(OUT_STATIC): $(OBJ) libdir includedir
+$(OUT_STATIC): $(OBJ) libdir
 	ar rcs $(OUT_STATIC) $(OBJ)
 
-$(OUT_STATIC_NO): $(OBJ_NO) libdir includedir
+$(OUT_STATIC_NO): $(OBJ_NO) libdir
 	ar rcs $(OUT_STATIC_NO) $(OBJ_NO)
-
 
 $(OUT_SHARED): $(OBJ) libdir
 	$(CCC) -shared $(OBJ) -o $(OUT_SHARED) $(LDFLAGS)
@@ -68,11 +71,13 @@ includedir: phiprof.mod
 	cp phiprof.hpp phiprof.h phiprof.mod ../include
 
 
+nofortranincludedir:
+	mkdir -p ../include
+	cp phiprof.hpp phiprof.h ../include
 
 clean:
-	rm -f $(OBJ) *.mod $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO)
+	rm -f $(OBJ) *.mod $(OUT_STATIC) $(OBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO) $(FOBJ) $(FOBJ_NO)
 
 phiprof.o: phiprof.hpp
-
 
 nophiprof.o: phiprof.hpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,3 @@
-
 # source files.
 SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
 SRC_NO = nophiprof.cpp phiprof_c.cpp
@@ -12,7 +11,7 @@ OUT_SHARED = ../lib/libphiprof.so
 OUT_SHARED_NO = ../lib/libnophiprof.so
 
 # Set the default compiler type (pgi, nvcc, gcc, intel, clang). Can be overriden from command-line.
-CC = nvcc
+CC = gcc
 
 # compiler calls
 CCC = mpicxx
@@ -42,6 +41,7 @@ else ifeq ($(CC),nvcc)
    CCFLAGS = --compiler-options -fpic -O2 -std=c++17 -DCLOCK_ID=$(CLOCK_ID)
    CCFLAGS +=  -D_NVTX -Xcompiler -fopenmp
    LDFLAGS += -lgomp -lnvToolsExt
+   CCC = OMPI_CXX='nvcc' OMPI_CXXFLAGS='' mpic++
 else ifeq ($(CC),gcc)
    CCFLAGS += -fopenmp -W -Wall -Wextra -pedantic 
    LDFLAGS += -lgomp
@@ -103,8 +103,6 @@ includedir-w-fortran: includedir
 includedir: 
 	mkdir -p ../include
 	cp phiprof.hpp phiprof.h  ../include
-
-
 
 clean:
 	rm -f $(OBJ) $(FOBJ) *.mod $(OUT_STATIC) $(OBJ_NO) $(FOBJ_NO) $(OUT_STATIC_NO) $(OUT_SHARED) $(OUT_SHARED_NO) ../include/* 

--- a/src/timertree.cpp
+++ b/src/timertree.cpp
@@ -131,6 +131,11 @@ bool TimerTree::stop (int id,
       return false;      
    }
 #endif
+
+#ifdef _NVTX
+   nvtxRangePop();
+#endif
+
    int newId = timers[id].stop(workUnits);
    setCurrentId(newId);   
    return true;
@@ -146,6 +151,11 @@ bool TimerTree::stop (int id,
       return false;
    }
 #endif
+
+#ifdef _NVTX
+   nvtxRangePop();
+#endif
+
    int newId = timers[id].stop(workUnits, workUnitLabel);
    setCurrentId(newId);
    return true;
@@ -161,6 +171,11 @@ bool TimerTree::stop (const std::string &label)
       return false;
    }
 #endif
+
+#ifdef _NVTX
+   nvtxRangePop();
+#endif
+
    setCurrentId(timers[currentId[thread]].stop());
    return true;
 }
@@ -177,6 +192,11 @@ bool TimerTree::stop (const std::string &label,
       return false;
    }
 #endif
+
+#ifdef _NVTX
+   nvtxRangePop();
+#endif
+
    setCurrentId(timers[currentId[thread]].stop(workUnits, workUnitLabel));
    return true;
 }

--- a/src/timertree.hpp
+++ b/src/timertree.hpp
@@ -27,6 +27,10 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 #include <omp.h>
 #endif
 
+#ifdef _NVTX
+#include "nvToolsExt.h"
+#endif
+
 class TimerTree {
 public:
    /**
@@ -78,6 +82,11 @@ public:
       //start timer (currentId = id)
       int newId = timers[id].start();
       setCurrentId(newId);
+
+#ifdef _NVTX
+      nvtxRangePush(timers[id].getLabel().c_str());
+#endif
+
       return true;
    }
 
@@ -133,8 +142,14 @@ public:
          return false;
       }
 #endif            
+
+#ifdef _NVTX
+      nvtxRangePop();
+#endif
+
       int newId = timers[id].stop();
       setCurrentId(newId);
+
       return true;
    }
    
@@ -209,9 +224,7 @@ protected:
 
    std::vector<int> currentId;
    std::vector<TimerData> timers;
-   
 
-   
 };
 
 


### PR DESCRIPTION
Tested on puhti with:

Currently Loaded Modules:
  1) pgi/19.7   2) hpcx-mpi/2.5.0-cuda   3) cuda/10.1.168

cd src
activate NVTX support in Makefile
make
cd ../example/nvtx_test
make
srun -n1 -p gputest --gres=gpu:v100:1 --account=project_2000203 --time=00:02:30 nvprof -f -o out.nvvp ./test
nvprof -i out.nvvp 
