### PR TITLE
Timer wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ nbproject
 vlasiator
 vlasiator+pat
 nbproject
+include/
+lib/

--- a/example/cpp_test/test.cpp
+++ b/example/cpp_test/test.cpp
@@ -60,93 +60,84 @@ int main(int argc,char **argv){
    
    phiprof::initialize();
    
-   phiprof::start("Benchmarking phiprof"); 
+   phiprof::Timer benchmark {"Benchmarking phiprof"}; 
 
-   phiprof::start("Initalized timers using ID");
+   phiprof::Timer init {"Initalized timers using ID"};
 
    if(rank==0)
       cout << "  1/3" <<endl;
-   int id_a=phiprof::initializeTimer("a","A with ID");
+   int id_a = phiprof::initializeTimer("a","A with ID");
    for(int i=0;i<nIterations;i++){
-      phiprof::start(id_a);
-      phiprof::stop(id_a);
+      phiprof::Timer a {id_a};
    }
-   phiprof::stop("Initalized timers using ID",nIterations,"start-stop");
+   init.stop(nIterations, "start-stop");
 
    if(rank==0)
       cout << "  2/3" <<endl;
 
-   phiprof::start("Re-initialized timers using ID");
+   phiprof::Timer reinit {"Re-initialized timers using ID"};
    for(int i=0;i<nIterations;i++){
       id_a=phiprof::initializeTimer("a","A with ID");
-      phiprof::start(id_a);
-      phiprof::stop(id_a);
+      phiprof::Timer a {id_a};
    }
-   phiprof::stop("Re-initialized timers using ID",nIterations,"start-stop");
+   reinit.stop(nIterations, "start-stop");
 
    if(rank==0)
       cout << "  3/3" <<endl;
-   phiprof::start("Timers using labels");
+   phiprof::Timer labels {"Timers using labels"};
    for(int i=0;i<nIterations;i++){
-      phiprof::start("a");
-      phiprof::stop("a");
+      phiprof::Timer a {"a"};
    }
-   phiprof::stop("Timers using labels", nIterations*2, "start-stop");
-   phiprof::stop("Benchmarking phiprof"); 
+   labels.stop(nIterations * 2, "start-stop"); // Why is it times two here?
+   benchmark.stop();
 
    MPI_Barrier(MPI_COMM_WORLD);
 
    if(rank==0)
       cout << "Measuring accuracy" <<endl;
 
-
-   phiprof::start("Test accuracy");
+   phiprof::Timer accuracy {"Test accuracy"};
 
    if(rank==0)
       cout << "  1/3" <<endl;
-   phiprof::start("100x0.01s computations"); 
+   phiprof::Timer computations {"100x0.01s computations"}; 
    for(int i=0;i<100;i++){
-      phiprof::start("compute");
+      phiprof::Timer t {"compute"};
       compute(0.01);
-      phiprof::stop("compute");
    }
-   phiprof::stop("100x0.01s computations");
+   computations.stop();
 
    if(rank==0)
       cout << "  2/3" <<endl;
    MPI_Barrier(MPI_COMM_WORLD);
 
-   phiprof::start("100 x 0.01 (threadId + 1)s, ID");
+   phiprof::Timer paraid {"100 x 0.01 (threadId + 1)s, ID"};
    int id = phiprof::initializeTimer("compute");
 #pragma omp parallel
    for(int i=0;i<100;i++){
-      phiprof::start(id);
+      phiprof::Timer t {id};
       compute(0.01 * (omp_get_thread_num() + 1));
-      phiprof::stop(id);
    }
-   phiprof::stop("100 x 0.01 (threadId + 1)s, ID"); 
+   paraid.stop();
 
    if(rank==0)
       cout << "  3/3" <<endl;
    MPI_Barrier(MPI_COMM_WORLD);
 
-   phiprof::start("100 x 0.01 (threadId + 1)s, String");
+   phiprof::Timer parastring {"100 x 0.01 (threadId + 1)s, String"};
 #pragma omp parallel
    for(int i=0;i<100;i++){
-      phiprof::start("compute");
+      phiprof::Timer t {"compute"};
       compute(0.01 * (omp_get_thread_num() + 1));
-      phiprof::stop("compute");
    }
-   phiprof::stop("100 x 0.01 (threadId + 1)s, String");
+   parastring.stop();
 
 
 
-   phiprof::stop("Test accuracy");
+   accuracy.stop();
 
    if(rank%2 == 1) {
-      
-      phiprof::start("Test-profile-groups");
-      phiprof::stop("Test-profile-groups");
+      phiprof::Timer groups {"Test-profile-groups"};
    }
    
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # source files.
-SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp  phiprof.cpp phiprof_c.cpp 
-SRC_NO = nophiprof.cpp phiprof_c.cpp
+SRC = prettyprinttable.cpp timerdata.cpp timertree.cpp paralleltimertree.cpp timer.cpp phiprof.cpp phiprof_c.cpp 
+SRC_NO = nophiprof.cpp phiprof_c.cpp timer.cpp
 OBJ = $(SRC:.cpp=.o) 
 FOBJ = phiprof_fortran.o
 OBJ_NO = $(SRC_NO:.cpp=.o) 

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -124,6 +124,42 @@ namespace phiprof
    int getChildId(const string &label){
       return parallelTimerTree.getChildId(label);
    }
+
+   Timer Timer::initialize(const std::string& label, const std::vector<std::string>& groups) {
+      return Timer(initializeTimer(label, groups));
+   }
+
+   Timer Timer::initialize(const std::string& label, const std::string& group) {
+      return initialize(label, {group});
+   }
+
+   Timer Timer::start(const std::string& label, const std::vector<std::string>& groups) {
+      Timer t {initialize(label, groups)};
+      t.start();
+      return t;
+   }
+
+   Timer Timer::start(const std::string& label, const std::string& group) {
+      return start(label, {group});
+   }
+
+   Timer::Timer(const int id) : id {id} {}
+
+   Timer::~Timer() {
+      this->stop();
+   }
+
+   bool Timer::start() {
+      return active = phiprof::start(this->id);
+   }
+
+   bool Timer::stop(const double workUnits, const std::string& workUnitLabel) {
+      if (!active)
+         return false;
+
+      active = false;
+      return phiprof::stop(id, workUnits, workUnitLabel);
+   }
    
 }
 

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -125,25 +125,12 @@ namespace phiprof
       return parallelTimerTree.getChildId(label);
    }
 
-   Timer Timer::initialize(const std::string& label, const std::vector<std::string>& groups) {
-      return Timer(initializeTimer(label, groups));
+   Timer::Timer(const int id) : id {id} {
+      this->start();
    }
 
-   Timer Timer::initialize(const std::string& label, const std::string& group) {
-      return initialize(label, {group});
-   }
-
-   Timer Timer::start(const std::string& label, const std::vector<std::string>& groups) {
-      Timer t {initialize(label, groups)};
-      t.start();
-      return t;
-   }
-
-   Timer Timer::start(const std::string& label, const std::string& group) {
-      return start(label, {group});
-   }
-
-   Timer::Timer(const int id) : id {id} {}
+   Timer::Timer(const string& label, const vector<string>& groups) : Timer(initializeTimer(label, groups)) {}
+   Timer::Timer(const string& label, const string& group) : Timer(label, vector<string> {group}) {}
 
    Timer::~Timer() {
       this->stop();
@@ -153,7 +140,7 @@ namespace phiprof
       return active ? false : (active = phiprof::start(this->id));
    }
 
-   bool Timer::stop(const double workUnits, const std::string& workUnitLabel) {
+   bool Timer::stop(const double workUnits, const string& workUnitLabel) {
       if (!active)
          return false;
 

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -130,7 +130,6 @@ namespace phiprof
    }
 
    Timer::Timer(const string& label, const vector<string>& groups) : Timer(initializeTimer(label, groups)) {}
-   Timer::Timer(const string& label, const string& group) : Timer(label, vector<string> {group}) {}
 
    Timer::~Timer() {
       this->stop();

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -150,7 +150,7 @@ namespace phiprof
    }
 
    bool Timer::start() {
-      return active = phiprof::start(this->id);
+      return active ? false : active = phiprof::start(this->id);
    }
 
    bool Timer::stop(const double workUnits, const std::string& workUnitLabel) {
@@ -162,7 +162,3 @@ namespace phiprof
    }
    
 }
-
-
-   
-   

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -150,7 +150,7 @@ namespace phiprof
    }
 
    bool Timer::start() {
-      return active ? false : active = phiprof::start(this->id);
+      return active ? false : (active = phiprof::start(this->id));
    }
 
    bool Timer::stop(const double workUnits, const std::string& workUnitLabel) {

--- a/src/phiprof.cpp
+++ b/src/phiprof.cpp
@@ -124,27 +124,5 @@ namespace phiprof
    int getChildId(const string &label){
       return parallelTimerTree.getChildId(label);
    }
-
-   Timer::Timer(const int id) : id {id} {
-      this->start();
-   }
-
-   Timer::Timer(const string& label, const vector<string>& groups) : Timer(initializeTimer(label, groups)) {}
-
-   Timer::~Timer() {
-      this->stop();
-   }
-
-   bool Timer::start() {
-      return active ? false : (active = phiprof::start(this->id));
-   }
-
-   bool Timer::stop(const double workUnits, const string& workUnitLabel) {
-      if (!active)
-         return false;
-
-      active = false;
-      return phiprof::stop(id, workUnits, workUnitLabel);
-   }
    
 }

--- a/src/phiprof.hpp
+++ b/src/phiprof.hpp
@@ -167,6 +167,29 @@ namespace phiprof
     */
    bool print(MPI_Comm comm, std::string fileNamePrefix="profile");
 
+   class Timer {
+      public:
+         static Timer start(const std::string& label, const std::vector<std::string>& groups = {});
+         static Timer start(const std::string& label, const std::string& group);
+         static Timer initialize(const std::string& label, const std::vector<std::string>& groups = {});
+         static Timer initialize(const std::string& label, const std::string& group);
+
+         ~Timer();
+         // Rule of five
+         Timer(const Timer&) = delete;
+         Timer& operator=(const Timer&) = delete;
+         Timer(Timer&&) = default;
+         Timer& operator=(Timer&&) = default;
+
+         bool start();
+         bool stop(const double workUnits = -1.0, const std::string& workUnitLabel = "");
+      private:
+         explicit Timer(const int id);
+
+         bool active {false};
+         int id {};
+   };
+
 }
 
 

--- a/src/phiprof.hpp
+++ b/src/phiprof.hpp
@@ -186,8 +186,8 @@ namespace phiprof
       private:
          explicit Timer(const int id);
 
+         const int id;
          bool active {false};
-         int id {};
    };
 
 }

--- a/src/phiprof.hpp
+++ b/src/phiprof.hpp
@@ -171,7 +171,6 @@ namespace phiprof
       public:
          explicit Timer(const int id);
          Timer(const std::string& label, const std::vector<std::string>& groups = {});
-         Timer(const std::string& label, const std::string& group);
 
          ~Timer();
          // Rule of five

--- a/src/phiprof.hpp
+++ b/src/phiprof.hpp
@@ -169,10 +169,9 @@ namespace phiprof
 
    class Timer {
       public:
-         static Timer start(const std::string& label, const std::vector<std::string>& groups = {});
-         static Timer start(const std::string& label, const std::string& group);
-         static Timer initialize(const std::string& label, const std::vector<std::string>& groups = {});
-         static Timer initialize(const std::string& label, const std::string& group);
+         explicit Timer(const int id);
+         Timer(const std::string& label, const std::vector<std::string>& groups = {});
+         Timer(const std::string& label, const std::string& group);
 
          ~Timer();
          // Rule of five
@@ -184,8 +183,6 @@ namespace phiprof
          bool start();
          bool stop(const double workUnits = -1.0, const std::string& workUnitLabel = "");
       private:
-         explicit Timer(const int id);
-
          const int id;
          bool active {false};
    };

--- a/src/phiprof.hpp
+++ b/src/phiprof.hpp
@@ -179,7 +179,7 @@ namespace phiprof
          Timer(const Timer&) = delete;
          Timer& operator=(const Timer&) = delete;
          Timer(Timer&&) = default;
-         Timer& operator=(Timer&&) = default;
+         Timer& operator=(Timer&&) = delete;
 
          bool start();
          bool stop(const double workUnits = -1.0, const std::string& workUnitLabel = "");

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,0 +1,29 @@
+#include <string>
+#include <vector>
+#include "phiprof.hpp"
+
+using namespace std;
+
+namespace phiprof {
+   Timer::Timer(const int id) : id {id} {
+      this->start();
+   }
+
+   Timer::Timer(const string& label, const vector<string>& groups) : Timer(initializeTimer(label, groups)) {}
+
+   Timer::~Timer() {
+      this->stop();
+   }
+
+   bool Timer::start() {
+      return active ? false : (active = phiprof::start(this->id));
+   }
+
+   bool Timer::stop(const double workUnits, const string& workUnitLabel) {
+      if (!active)
+         return false;
+
+      active = false;
+      return phiprof::stop(id, workUnits, workUnitLabel);
+   }
+}


### PR DESCRIPTION
Adds class `phiprof::Timer` to prevent dangling timers. 

A timer `t` is initialized and started via `phiprof::Timer t (args)` where `args` is a valid list of arguments for `phiprof::start(args)` or `phiprof::initialize(args)`. The timer can be stopped if active with `t.stop()` and started if inactive with `t.start()`. The destructor automatically stops the associated timer, e.g. when going out of scope.