### PR TITLE
Add functionality to export flamegraph data 

### DIFF
--- a/src/paralleltimertree.cpp
+++ b/src/paralleltimertree.cpp
@@ -513,7 +513,6 @@ bool ParallelTimerTree::generateFlameGraphDataFile(
       return true;
     }
 
-    constexpr std::size_t max_loops = 1000;
     std::vector<double> exclusiveTimeSum = stats.timeSum;
     std::vector<int> parentIndexStack;
     // Calculate exclusive timers for flamegraph by removing children

--- a/src/paralleltimertree.cpp
+++ b/src/paralleltimertree.cpp
@@ -31,7 +31,6 @@ License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 #include "paralleltimertree.hpp"
 #include "prettyprinttable.hpp"
 #include "common.hpp"
-#include <numeric>
 #ifdef _OPENMP
 #include "omp.h"
 #endif

--- a/src/paralleltimertree.cpp
+++ b/src/paralleltimertree.cpp
@@ -521,7 +521,6 @@ bool ParallelTimerTree::generateFlameGraphDataFile(
       const int currentLevel = stats.level[i];
       while (!parentIndexStack.empty() &&
              stats.level[parentIndexStack.back()] >= currentLevel) {
-        counter++;
         parentIndexStack.pop_back();
       }
 

--- a/src/paralleltimertree.hpp
+++ b/src/paralleltimertree.hpp
@@ -114,6 +114,8 @@ private:
                     const std::map<std::string, std::string> &groupIds,                  
                     std::ofstream &output);   
    
+   bool generateFlameGraphDataFile(const std::string &outputPath);
+   
    bool printGroupStatistics(double minFraction,
                              const std::map<std::string, std::string> &groupIds,
                              std::ofstream &output);


### PR DESCRIPTION
This PR adds functionality in the paralleltimertree.cpp to generate flamegraph stack traces. When Vlasiator finishes ```phiprof_flamegraph.txt``` is also dumped. Later on we can use any kind of script that digests the stack trace to produce nice interactive svg flamegrapghs.

Example using [FlameGraph](https://github.com/brendangregg/FlameGraph). These are cool because they are interactive and searchable.
```
git clone https://github.com/brendangregg/FlameGraph
cat phiprof_flamegraph.txt | ./FlameGraph/flamegraph.pl > new.svg
```
produces:
![new](https://github.com/user-attachments/assets/649064b1-2367-4a2a-8399-1eb6526369b7)
which can be opened with any modern browser and is interactive like [this](https://www.brendangregg.com/FlameGraphs/cpu-bash-flamegraph.svg) but I cannot host it now.
